### PR TITLE
Add support for String.prototype.matchAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Supported methods:
 The following well-known symbol-based methods are supported (see [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)):
 
 * [`re2[Symbol.match](str)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match)
+* [`re2[Symbol.matchAll](str)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll)
 * [`re2[Symbol.search](str)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search)
 * [`re2[Symbol.replace](str, newSubStr|function)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)
 * [`re2[Symbol.split](str[, limit])`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split)

--- a/src/re2.ts
+++ b/src/re2.ts
@@ -390,7 +390,9 @@ export class RE2 {
     return this[Symbol.match](input);
   }
 
-  *[Symbol.matchAll](input: string): Generator<RE2MatchArray> {
+  *[(Symbol as SymbolConstructor & {matchAll?: symbol}).matchAll || Symbol()](
+    input: string
+  ): Generator<RE2MatchArray> {
     const copy = new RE2(this);
     copy.lastIndex = this.lastIndex;
 

--- a/src/re2.ts
+++ b/src/re2.ts
@@ -390,6 +390,19 @@ export class RE2 {
     return this[Symbol.match](input);
   }
 
+  *[Symbol.matchAll](input: string): Generator<RE2MatchArray> {
+    const copy = new RE2(this);
+    copy.lastIndex = this.lastIndex;
+
+    for (;;) {
+      const match = copy.exec(input);
+      if (match === null) {
+        break;
+      }
+      yield match;
+    }
+  }
+
   /**
    * Outputs the replacement for the matched part of the string
    * @param input

--- a/third_party/node-re2/tests/test_matchAll.js
+++ b/third_party/node-re2/tests/test_matchAll.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const unit = require('heya-unit');
+const RE2 = require('../../..').RE2;
+
+// tests
+
+unit.add(module, [
+  // These tests are copied from MDN:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
+
+  function test_matchAll(t) {
+    'use strict';
+
+    const str = 'test1test2';
+    const re = new RE2(/t(e)(st(\d?))/gu);
+    const result = Array.from(str.matchAll(re));
+
+    eval(t.TEST('result.length === 2'));
+    eval(t.TEST('result[0].input === str'));
+    eval(t.TEST('result[0].index === 0'));
+    eval(t.TEST('result[0].length === 4'));
+    eval(t.TEST("result[0][0] === 'test1'"));
+    eval(t.TEST("result[0][1] === 'e'"));
+    eval(t.TEST("result[0][2] === 'st1'"));
+    eval(t.TEST("result[0][3] === '1'"));
+    eval(t.TEST('result[1].input === str'));
+    eval(t.TEST('result[1].index === 5'));
+    eval(t.TEST('result[1].length === 4'));
+    eval(t.TEST("result[1][0] === 'test2'"));
+    eval(t.TEST("result[1][1] === 'e'"));
+    eval(t.TEST("result[1][2] === 'st2'"));
+    eval(t.TEST("result[1][3] === '2'"));
+  },
+
+  function test_matchAll_iterator(t) {
+    'use strict';
+
+    const str = 'table football, foosball';
+    const re = new RE2('foo[a-z]*', 'gu');
+
+    const expected = [
+      {start: 6, finish: 14},
+      {start: 16, finish: 24},
+    ];
+    let i = 0;
+    for (const match of str.matchAll(re)) {
+      eval(t.TEST('match.index === expected[i].start'));
+      eval(t.TEST('match.index + match[0].length === expected[i].finish'));
+      ++i;
+    }
+  },
+
+  function test_matchAll_non_global(t) {
+    'use strict';
+
+    const re = new RE2('b', 'u');
+
+    try {
+      'abc'.matchAll(re);
+      t.test(false); // shouldn't be here
+    } catch (e) {
+      eval(t.TEST('e instanceof TypeError'));
+    }
+  },
+
+  function test_matchAll_lastIndex(t) {
+    'use strict';
+
+    const re = new RE2('[a-c]', 'gu');
+    re.lastIndex = 1;
+
+    const expected = ['b', 'c'];
+    let i = 0;
+    for (const match of 'abc'.matchAll(re)) {
+      eval(t.TEST('re.lastIndex === 1'));
+      eval(t.TEST('match[0] === expected[i]'));
+      ++i;
+    }
+  },
+]);

--- a/third_party/node-re2/tests/tests.js
+++ b/third_party/node-re2/tests/tests.js
@@ -16,5 +16,6 @@ require("./test_invalid");
 require("./test_symbols");
 require("./test_prototype");
 require("./test_groups");
+require("./test_matchAll");
 
 unit.run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "lib": ["es2017"],
-    "target": "es2017",
+    "lib": ["es2020"],
+    "target": "es2020",
     "moduleResolution": "node"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "lib": ["es2020"],
-    "target": "es2020",
+    "lib": ["es2017"],
+    "target": "es2017",
     "moduleResolution": "node"
   },
   "include": [


### PR DESCRIPTION
This PR adds support for `String.prototype.matchAll(regexp)` where `regexp` is an RE2 instance.

BEGIN_COMMIT_OVERRIDE
feat: Add support for String.prototype.matchAll()
END_COMMIT_OVERRIDE